### PR TITLE
Add contracts to files

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "tools:surya:report": "surya mdreport build/docs/surya-report.md contracts/TokenVesting.sol"
   },
   "files": [
-    "build/abi"
+    "build/abi",
+    "contracts"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
Hi again:) I'd like to ask if you'd be ok with adding contracts to the `package.json`, so that I can depend on your repository with my contracts - I want to leverage the code for my project, but I don't want to fork it, just to build a wrapper simplifying the API fit for out use case.

This would allow me to simply add your repo to `package.json` like with for example Openzeppelin contracts