### PR TITLE
Update TokenVesting.sol

### DIFF
--- a/src/TokenVesting.sol
+++ b/src/TokenVesting.sol
@@ -16,9 +16,9 @@ contract TokenVesting is Owned, ReentrancyGuard {
         bool initialized;
         // beneficiary of tokens after they are released
         address beneficiary;
-        // cliff period in seconds
+        // cliff time of the vesting start in seconds since the UNIX epoch
         uint256 cliff;
-        // start time of the vesting period
+        // start time of the vesting period in seconds since the UNIX epoch
         uint256 start;
         // duration of the vesting period in seconds
         uint256 duration;


### PR DESCRIPTION
Fix comment.
While the _cliff param of createVestingSchedule() is a duration, inside the VestingSchedule struct it represents time since epoch.
The original comment is a bit confusing.